### PR TITLE
Remove separate TT, TE and EE likelihoods from example

### DIFF
--- a/examples/hillipop_example.yaml
+++ b/examples/hillipop_example.yaml
@@ -1,9 +1,6 @@
 debug: True
 
 likelihood:
-  planck_2020_hillipop.TT: null
-  planck_2020_hillipop.EE: null
-  planck_2020_hillipop.TE: null
   planck_2020_hillipop.TTTEEE: null
 
 params:


### PR DESCRIPTION
I think if TTTEEE is used, then TT, TE and EE should not be included.