### PR TITLE
Suggestions for the binning and cutting in `v4.3`

### DIFF
--- a/planck_2020_hillipop/TE.bibtex
+++ b/planck_2020_hillipop/TE.bibtex
@@ -1,1 +1,0 @@
-hillipop.bibtex

--- a/planck_2020_hillipop/TT.bibtex
+++ b/planck_2020_hillipop/TT.bibtex
@@ -1,1 +1,0 @@
-hillipop.bibtex

--- a/planck_2020_hillipop/TTTEEE.bibtex
+++ b/planck_2020_hillipop/TTTEEE.bibtex
@@ -1,1 +1,0 @@
-hillipop.bibtex

--- a/planck_2020_hillipop/TTTEEE_bin.bibtex
+++ b/planck_2020_hillipop/TTTEEE_bin.bibtex
@@ -1,1 +1,0 @@
-hillipop.bibtex

--- a/planck_2020_hillipop/TT_bin.bibtex
+++ b/planck_2020_hillipop/TT_bin.bibtex
@@ -1,1 +1,0 @@
-hillipop.bibtex

--- a/planck_2020_hillipop/hillipop.bibtex
+++ b/planck_2020_hillipop/hillipop.bibtex
@@ -1,16 +1,17 @@
-Planck high-multipole HiLLiPOP likelihood from \cite{Tristram:2023}
-
 @ARTICLE{Tristram:2023,
-       author = {{Tristram}, M. and {Banday}, A.~J. and {Douspis}, M. and {Garrido}, X. and {G{\'o}rski}, K.~M. and {Henrot-Versill{\'e}}, S. and {Ili{\'c}}, S. and {Keskitalo}, R. and {Lagache}, G. and {Lawrence}, C.~R. and {Partridge}, B. and {Scott}, D.},
-        title = "{Cosmological parameters derived from the final (PR4) Planck data release}",
+       author = {{Tristram}, M. and {Banday}, A.~J. and {Douspis}, M. and {Garrido}, X. and {G{\'o}rski}, K.~M. and {Henrot-Versill{\'e}}, S. and {Hergt}, L.~T. and {Ili{\'c}}, S. and {Keskitalo}, R. and {Lagache}, G. and {Lawrence}, C.~R. and {Partridge}, B. and {Scott}, D.},
+        title = "{Cosmological parameters derived from the final Planck data release (PR4)}",
       journal = {\aap},
-     keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-         year = 2023,
-        month = sep,
-       volume = {accepted},
-          doi = {10.48550/arXiv.2309.10034},
+     keywords = {cosmic background radiation, methods: data analysis, cosmological parameters, cosmology: observations, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = 2024,
+        month = feb,
+       volume = {682},
+          doi = {10.1051/0004-6361/202348015},
+          eid = {A37},
+        pages = {A37},
 archivePrefix = {arXiv},
        eprint = {2309.10034},
  primaryClass = {astro-ph.CO},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024A&A...682A..37T},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-

--- a/planck_2020_hillipop/hillipop.py
+++ b/planck_2020_hillipop/hillipop.py
@@ -1,7 +1,25 @@
-#
-# HILLIPOP
-#
-# Sep 2020   - M. Tristram -
+"""
+.. module:: HiLLiPoP
+
+:Synopsis: Likelihood class for Planck PR4
+:Author: Matthieu Tristram
+
+Hillipop is a multifrequency CMB likelihood for Planck data.
+
+The likelihood is a spectrum-based Gaussian approximation for
+cross-correlation spectra from Planck 100, 143 and 217GHz
+split-frequency maps, with semi-analytic estimates of the Cl
+covariance matrix based on the data. The cross-spectra are debiased
+from the effects of the mask and the beam leakage using Xpol before
+being compared to the model, which includes CMB and foreground
+residuals. They cover the multipoles from l=30 to l=2500.
+
+:History: 
+ Sep 2020   - M. Tristram -
+ Apr 2026   - M. Tristram, L. Hergt - Implement binned version
+
+"""
+
 import glob
 import logging
 import os
@@ -19,6 +37,12 @@ from cobaya.mpi import is_main_process
 
 from . import foregrounds as fg
 from . import tools
+
+#predefined binning
+lower_l = np.arange( 30,  251,  1)  # unbinned
+upper_l = np.arange(251, 2500, 10)  # binned
+bin_lmins = np.concatenate((lower_l, upper_l))
+bin_lmaxs = np.concatenate((lower_l, upper_l + 9))
 
 
 # ------------------------------------------------------------------------------------------------
@@ -81,10 +105,6 @@ class _HillipopLikelihood(InstallableLikelihood):
         self.lmin = min(min(self._lmins[mode]) for mode, is_mode in self._is_mode.items() if is_mode)
         self.lmax = max(max(self._lmaxs[mode]) for mode, is_mode in self._is_mode.items() if is_mode)
         if 'bin' in self.__class__.__name__:
-            lower_l = np.arange(self.lmin, 251, 1)   # unbinned
-            upper_l = np.arange(251, self.lmax, 10)  # binned
-            bin_lmins = np.concatenate((lower_l, upper_l))
-            bin_lmaxs = np.concatenate((lower_l, upper_l + 9))
             self.wf = tools.Bins(bin_lmins, bin_lmaxs)
         else:
             self.wf = tools.Bins.fromdeltal(2, self.lmax+1, 1)

--- a/planck_2020_hillipop/hillipop.py
+++ b/planck_2020_hillipop/hillipop.py
@@ -223,48 +223,47 @@ class _HillipopLikelihood(InstallableLikelihood):
         Apply multipole cuts from `lrange` on the covariance matrix and lmins/lmaxs.
         """
 
-        # invert matrix
-        self.log.debug("\tInvert invkll matrix")
-        kll = np.linalg.inv( self._invkll)
-
         # resize with lmax
-        self.log.debug("\tApply lmin/lmax")
+        self.log.debug(f"\tSet up lmin/lmax cuts for lrange:\n{self.lrange}")
         shift = 0
         idxs = []
         for mode in ["TT", "EE", "TE"]:
-            if self._is_mode[mode] is False: continue
-            lmin, lmax = self.lrange[mode]  # define lrange for the likelihood
+            if not self._is_mode[mode]:
+                continue
+            lmin_cut, lmax_cut = self.lrange[mode]
+
+            # validate lrange
+            if lmin_cut < min(self._lmins[mode]):
+                raise LoggedError(self.log, f"{mode} lmin should be >= {min(self._lmins[mode])} (lmin={lmin_cut} requested)")
+            if lmax_cut > max(self._lmaxs[mode]):
+                raise LoggedError(self.log, f"{mode} lmax should be <= {max(self._lmaxs[mode])} (lmax={lmax_cut} requested)")
+
+            # build index list for covariance cutting
             for xf in range(self._nxfreq):
                 xflmin = self._lmins[mode][self._xspec2xfreq.index(xf)]
                 xflmax = self._lmaxs[mode][self._xspec2xfreq.index(xf)]
 
-                # original binning of the bin kll
-                wf = deepcopy( self.wf)
-                wf.cut_binning( xflmin, xflmax)
+                wf = deepcopy(self.wf)
+                wf.cut_binning(xflmin, xflmax)
 
-                # apply overall lmin,lmax
                 for i in range(wf.nbins):
-                    if wf.lmins[i] >= lmin and wf.lmaxs[i] <= lmax: idxs.append(shift+i)
+                    if wf.lmins[i] >= lmin_cut and wf.lmaxs[i] <= lmax_cut: idxs.append(shift+i)
                 shift += wf.nbins
 
-        kll = kll[idxs,:][:,idxs]
+            # integrate lrange into _lmins/_lmaxs
+            self._lmins[mode] = np.maximum(self._lmins[mode], lmin_cut)
+            self._lmaxs[mode] = np.minimum(self._lmaxs[mode], lmax_cut)
 
-        # invert matrix
-        self.log.debug("\tInvert kll matrix")
-        self._invkll = np.linalg.inv( kll)
-
-        # Integrate lrange into _lmins/_lmaxs
-        for mode, lrange in self.lrange.items():
-            if lrange[0] < min(self._lmins[mode]):
-                raise LoggedError(self.log, f"{mode} lmin should be >= {min(self._lmins[mode])} (lmin={lrange[0]} requested)")
-            if lrange[1] > max(self._lmaxs[mode]):
-                raise LoggedError(self.log, f"{mode} lmax should be <= {max(self._lmaxs[mode])} (lmax={lrange[1]} requested)")
-            self._lmins[mode] = np.maximum(self._lmins[mode], lrange[0])
-            self._lmaxs[mode] = np.minimum(self._lmaxs[mode], lrange[1])
         self._lmins['ET'] = self._lmins['TE']
         self._lmaxs['ET'] = self._lmaxs['TE']
         self.lmax = max(max(self._lmaxs[mode]) for mode in self.lrange)
-    
+
+        # invert matrix
+        self.log.debug("\tInvert invkll matrix")
+        kll = np.linalg.inv(self._invkll)
+        kll = kll[idxs,:][:,idxs]
+        self.log.debug("\tInvert kll matrix")
+        self._invkll = np.linalg.inv( kll)
 
     def _get_matrix_size(self):
         """

--- a/planck_2020_hillipop/hillipop.py
+++ b/planck_2020_hillipop/hillipop.py
@@ -20,10 +20,11 @@ from . import foregrounds as fg
 from . import tools
 
 
-#bintab for Hillipop bin
-bin_lmins = list( np.arange(30, 251, 1))+list( np.arange(251, 2500, 10))
-bin_lmaxs = list( np.arange(30, 251, 1))+list( np.arange(251, 2500, 10)+9)
-
+# binning for Hillipop binned likelihoods
+lower_l = np.arange(30, 251, 1)     # unbinned
+upper_l = np.arange(251, 2500, 10)  # binned
+bin_lmins = np.concatenate((lower_l, upper_l))
+bin_lmaxs = np.concatenate((lower_l, upper_l + 9))
 
 
 # ------------------------------------------------------------------------------------------------
@@ -38,9 +39,8 @@ class _HillipopLikelihood(InstallableLikelihood):
     multipoles_range_file: Optional[str]
     xspectra_basename: Optional[str]
     covariance_matrix_file: Optional[str]
-    foregrounds: Optional[list]
-
-    lrange: Optional[list]
+    foregrounds: Optional[dict]
+    lrange: Optional[dict]
 
     def initialize(self):
         # Set path to data
@@ -118,7 +118,7 @@ class _HillipopLikelihood(InstallableLikelihood):
         #DO NOT cut l-by-l likelihood !
         if 'bin' in self.__class__.__name__:
             self._cut_covmatrix( self.lrange)
-#            self.wf.cut_binning( self.lmin, self.lmax)
+
         self._invkll = self._invkll.astype('float32')
 
         for xs, (m1, m2) in enumerate(combinations(self._mapnames, 2)):
@@ -127,10 +127,10 @@ class _HillipopLikelihood(InstallableLikelihood):
                 if self._is_mode[mode]:
                     xflmin = self._lmins[mode][xs]
                     xflmax = self._lmaxs[mode][xs]
-                    mywf = deepcopy( self.wf)
-                    mywf.cut_binning( *self.lrange[mode])
-                    mywf.cut_binning( xflmin, xflmax)
-                    logstr += f"{mode}[{mywf.lmin:4d}-{mywf.lmax:4d}]  "
+                    wf = deepcopy( self.wf)
+                    wf.cut_binning( *self.lrange[mode])
+                    wf.cut_binning( xflmin, xflmax)
+                    logstr += f"{mode}[{wf.lmin:4d}-{wf.lmax:4d}]  "
             self.log.info(logstr)
 
         # Foregrounds
@@ -150,7 +150,7 @@ class _HillipopLikelihood(InstallableLikelihood):
                     kwargs["filenames"] = (self.foregrounds[tag]["tsz"] and os.path.join(self.fgds_folder, self.foregrounds[tag]["tsz"]),
                                            self.foregrounds[tag]["cib"] and os.path.join(self.fgds_folder, self.foregrounds[tag]["cib"]))
                 fgs.append(getattr(fg,name)(**kwargs))
-        
+
         self.log.info("Initialized!")
 
     def _xspec2xfreq(self):
@@ -186,10 +186,6 @@ class _HillipopLikelihood(InstallableLikelihood):
                 tag = hdu.header['spec']
                 lmins[tag] = hdu.data.LMIN
                 lmaxs[tag] = hdu.data.LMAX
-#                if self._is_mode[tag]:
-#                    self.log.debug(f"{tag}")
-#                    for xs, (m1, m2) in enumerate(combinations(self._mapnames, 2)):
-#                        self.log.debug(f"{m1}x{m2} : {lmins[tag][xs]} - {lmaxs[tag][xs]}")
         lmins["ET"] = lmins["TE"]
         lmaxs["ET"] = lmaxs["TE"]
 
@@ -230,7 +226,6 @@ class _HillipopLikelihood(InstallableLikelihood):
         if not os.path.exists(filename):
             raise ValueError(f"File missing {filename}")
 
-        print(filename)
         data = fits.getdata(filename)
         nel = int(np.sqrt(data.size))
         data = data.reshape((nel, nel)) / 1e24  # muK^-4
@@ -247,11 +242,11 @@ class _HillipopLikelihood(InstallableLikelihood):
         lrange : dict( TT=(lmin,lmax), TE=(lmin,lmax), EE=(lmin,lmax)
         """
 
-        #invert matrix
+        # invert matrix
         self.log.debug("\tInvert invkll matrix")
         kll = np.linalg.inv( self._invkll)
         
-        #resize with lmax
+        # resize with lmax
         self.log.debug("\tApply lmin/lmax")
         shift = 0
         idxs = []
@@ -262,19 +257,18 @@ class _HillipopLikelihood(InstallableLikelihood):
                 xflmin = self._lmins[mode][self._xspec2xfreq.index(xf)]
                 xflmax = self._lmaxs[mode][self._xspec2xfreq.index(xf)]
 
-                #original binning of the bin kll
-                mywf = deepcopy( self.wf)
-                mywf.cut_binning( xflmin, xflmax)
+                # original binning of the bin kll
+                wf = deepcopy( self.wf)
+                wf.cut_binning( xflmin, xflmax)
 
-                #apply overall lmin,lmax
-                for i in range(mywf.nbins):
-                    if mywf.lmins[i] >= lmin and mywf.lmaxs[i] <= lmax: idxs.append(shift+i)
-                shift += mywf.nbins
-#                print( f"{mode},{xf} : {len(idxs)} / {mywf.nbins} / {shift}")
+                # apply overall lmin,lmax
+                for i in range(wf.nbins):
+                    if wf.lmins[i] >= lmin and wf.lmaxs[i] <= lmax: idxs.append(shift+i)
+                shift += wf.nbins
 
         kll = kll[idxs,:][:,idxs]
 
-        #invert matrix
+        # invert matrix
         self.log.debug("\tInvert kll matrix")
         self._invkll = np.linalg.inv( kll)
     
@@ -289,14 +283,12 @@ class _HillipopLikelihood(InstallableLikelihood):
         # TT,EE,TEET
         for m in ["TT", "EE", "TE"]:
             if self._is_mode[m]:
-#                nells = self._lmaxs[m] - self._lmins[m] + 1
-#                nell += np.sum([nells[self._xspec2xfreq.index(k)] for k in range(self._nxfreq)])
                 for xf in range(self._nxfreq):
                     lmin = self._lmins[m][self._xspec2xfreq.index(xf)]
                     lmax = self._lmaxs[m][self._xspec2xfreq.index(xf)]
-                    mywf = deepcopy( self.wf)
-                    mywf.cut_binning( lmin, lmax)
-                    nell += mywf.nbins
+                    wf = deepcopy( self.wf)
+                    wf.cut_binning( lmin, lmax)
+                    nell += wf.nbins
 
         return nell
 
@@ -310,10 +302,10 @@ class _HillipopLikelihood(InstallableLikelihood):
         for xf in range(self._nxfreq):
             lmin = self._lmins[mode][self._xspec2xfreq.index(xf)]
             lmax = self._lmaxs[mode][self._xspec2xfreq.index(xf)]
-            mywf = deepcopy( self.wf)
-            mywf.cut_binning( lmin, lmax)
-            mywf.cut_binning( *self.lrange[mode])
-            xl += list(mywf.bin_spectra(acl[xf]))
+            wf = deepcopy( self.wf)
+            wf.cut_binning( lmin, lmax)
+            wf.cut_binning( *self.lrange[mode])
+            xl += list(wf.bin_spectra(acl[xf]))
         return xl
 
     def _xspectra_to_xfreq(self, cl, weight, normed=True):
@@ -517,18 +509,17 @@ def _get_install_options(filename):
 class TTTEEE(_HillipopLikelihood):
     """High-L TT+TE+EE Likelihood for Polarized Planck Spectra-based Gaussian-approximated likelihood
     with foreground models for cross-correlation spectra from Planck 100, 143 and 217 GHz
-    split-frequency maps
+    split-frequency maps.
 
     """
 
     install_options = _get_install_options("planck_2020_hillipop_TTTEEE_v4.2.tar.gz")
 
 
-
 class TT(_HillipopLikelihood):
     """High-L TT Likelihood for Polarized Planck Spectra-based Gaussian-approximated likelihood with
     foreground models for cross-correlation spectra from Planck 100, 143 and 217 GHz split-frequency
-    maps
+    maps.
 
     """
 
@@ -538,7 +529,7 @@ class TT(_HillipopLikelihood):
 class EE(_HillipopLikelihood):
     """High-L EE Likelihood for Polarized Planck Spectra-based Gaussian-approximated likelihood with
     foreground models for cross-correlation spectra from Planck 100, 143 and 217 GHz split-frequency
-    maps
+    maps.
 
     """
 
@@ -548,30 +539,31 @@ class EE(_HillipopLikelihood):
 class TE(_HillipopLikelihood):
     """High-L TE Likelihood for Polarized Planck Spectra-based Gaussian-approximated likelihood with
     foreground models for cross-correlation spectra from Planck 100, 143 and 217 GHz split-frequency
-    maps
+    maps.
 
     """
 
     install_options = _get_install_options("planck_2020_hillipop_TE_v4.2.tar.gz")
 
 
-
 class TT_bin(_HillipopLikelihood):
     """High-L TT Likelihood for Polarized Planck Spectra-based Gaussian-approximated likelihood with
     foreground models for cross-correlation spectra from Planck 100, 143 and 217 GHz split-frequency
-    maps
-    Binned version
+    maps.
+    Binned version.
 
     """
 
     install_options = _get_install_options("planck_2020_hillipop_TT_bin_v4.2.tar.gz")
 
+
 class TTTEEE_bin(_HillipopLikelihood):
     """High-L TT+TE+EE Likelihood for Polarized Planck Spectra-based Gaussian-approximated likelihood
     with foreground models for cross-correlation spectra from Planck 100, 143 and 217 GHz
-    split-frequency maps
-    Binned version
+    split-frequency maps.
+    Binned version.
 
     """
 
     install_options = _get_install_options("planck_2020_hillipop_TTTEEE_bin_v4.2.tar.gz")
+

--- a/planck_2020_hillipop/hillipop.py
+++ b/planck_2020_hillipop/hillipop.py
@@ -20,13 +20,6 @@ from . import foregrounds as fg
 from . import tools
 
 
-# binning for Hillipop binned likelihoods
-lower_l = np.arange(30, 251, 1)     # unbinned
-upper_l = np.arange(251, 2500, 10)  # binned
-bin_lmins = np.concatenate((lower_l, upper_l))
-bin_lmaxs = np.concatenate((lower_l, upper_l + 9))
-
-
 # ------------------------------------------------------------------------------------------------
 # Likelihood
 # ------------------------------------------------------------------------------------------------
@@ -80,19 +73,26 @@ class _HillipopLikelihood(InstallableLikelihood):
         self._is_mode["ET"] = self._is_mode["TE"]
         self.log.debug(f"mode = {self._is_mode}")
 
-        # Multipole ranges
+        # Multipole ranges and binning
         filename = os.path.join(self.data_folder, self.multipoles_range_file)
         self._lmins, self._lmaxs = self._set_multipole_ranges(filename)
+        self.lmin = min(min(self._lmins[mode]) for mode, is_mode in self._is_mode.items() if is_mode)
+        self.lmax = max(max(self._lmaxs[mode]) for mode, is_mode in self._is_mode.items() if is_mode)
         if 'bin' in self.__class__.__name__:
-            for tag,lrange in self.lrange.items():
-                if lrange[0] < min(self._lmins[tag]):
-                    raise LoggedError( self.log, f"{tag} lmin should be >= {min(self._lmins[tag])} (lmin={lrange[0]})")
-                if lrange[1] > max(self._lmaxs[tag]):
-                    raise LoggedError( self.log, f"{tag} lmax should be <= {max(self._lmaxs[tag])} (lmax={lrange[1]})")
+            lower_l = np.arange(self.lmin, 251, 1)   # unbinned
+            upper_l = np.arange(251, self.lmax, 10)  # binned
+            bin_lmins = np.concatenate((lower_l, upper_l))
+            bin_lmaxs = np.concatenate((lower_l, upper_l + 9))
+            self.wf = tools.Bins(bin_lmins, bin_lmaxs)
         else:
-            #lrange fixed for unbinned (TT:[30-2500], EE:[30-2000], TE:[30-2000]
-            self.lrange = {tag:[min(self._lmins[tag]),max(self._lmaxs[tag])] for tag,is_tag in self._is_mode.items() if is_tag}
-        self.lmax = max([lrange[1] for lrange in self.lrange.values()])
+            self.wf = tools.Bins.fromdeltal(2, self.lmax+1, 1)
+
+        # Inverted Covariance matrix
+        filename = os.path.join(self.data_folder, self.covariance_matrix_file)
+        self._invkll = self._read_invcovmatrix(filename)
+        if 'bin' in self.__class__.__name__ and self.lrange:
+            self._cut_lrange()  # optional lrange cutting only for binned likelihood
+        self._invkll = self._invkll.astype('float32')
 
         # Data
         basename = os.path.join(self.data_folder, self.xspectra_basename)
@@ -103,24 +103,6 @@ class _HillipopLikelihood(InstallableLikelihood):
         for m,w8 in dlsig.items(): w8[w8==0] = np.inf
         self._dlweight = {k:1/v**2 for k,v in dlsig.items()}
 
-        #Bin strategy
-        if 'bin' in self.__class__.__name__:
-            self.bmins,self.bmaxs = bin_lmins, bin_lmaxs
-        else:
-            self.bmins = self.bmaxs = np.arange(2,2500+1)
-        self.wf = tools.Bins( self.bmins, self.bmaxs)
-
-        # Inverted Covariance matrix
-        filename = os.path.join(self.data_folder, self.covariance_matrix_file)
-        self._invkll = self._read_invcovmatrix(filename)
-
-        #Cut lmin,lmax
-        #DO NOT cut l-by-l likelihood !
-        if 'bin' in self.__class__.__name__:
-            self._cut_covmatrix( self.lrange)
-
-        self._invkll = self._invkll.astype('float32')
-
         for xs, (m1, m2) in enumerate(combinations(self._mapnames, 2)):
             logstr = f"{m1}x{m2}: "
             for mode in ['TT','EE','TE']:
@@ -128,7 +110,6 @@ class _HillipopLikelihood(InstallableLikelihood):
                     xflmin = self._lmins[mode][xs]
                     xflmax = self._lmaxs[mode][xs]
                     wf = deepcopy( self.wf)
-                    wf.cut_binning( *self.lrange[mode])
                     wf.cut_binning( xflmin, xflmax)
                     logstr += f"{mode}[{wf.lmin:4d}-{wf.lmax:4d}]  "
             self.log.info(logstr)
@@ -237,23 +218,22 @@ class _HillipopLikelihood(InstallableLikelihood):
 
         return data
 
-    def _cut_covmatrix( self, lrange):
+    def _cut_lrange(self):
         """
-        Apply lmin/lmax on the covariance matrix
-        lrange : dict( TT=(lmin,lmax), TE=(lmin,lmax), EE=(lmin,lmax)
+        Apply multipole cuts from `lrange` on the covariance matrix and lmins/lmaxs.
         """
 
         # invert matrix
         self.log.debug("\tInvert invkll matrix")
         kll = np.linalg.inv( self._invkll)
-        
+
         # resize with lmax
         self.log.debug("\tApply lmin/lmax")
         shift = 0
         idxs = []
         for mode in ["TT", "EE", "TE"]:
             if self._is_mode[mode] is False: continue
-            lmin,lmax = lrange[mode]  #define lrange for the likelihood
+            lmin, lmax = self.lrange[mode]  # define lrange for the likelihood
             for xf in range(self._nxfreq):
                 xflmin = self._lmins[mode][self._xspec2xfreq.index(xf)]
                 xflmax = self._lmaxs[mode][self._xspec2xfreq.index(xf)]
@@ -272,6 +252,18 @@ class _HillipopLikelihood(InstallableLikelihood):
         # invert matrix
         self.log.debug("\tInvert kll matrix")
         self._invkll = np.linalg.inv( kll)
+
+        # Integrate lrange into _lmins/_lmaxs
+        for mode, lrange in self.lrange.items():
+            if lrange[0] < min(self._lmins[mode]):
+                raise LoggedError(self.log, f"{mode} lmin should be >= {min(self._lmins[mode])} (lmin={lrange[0]} requested)")
+            if lrange[1] > max(self._lmaxs[mode]):
+                raise LoggedError(self.log, f"{mode} lmax should be <= {max(self._lmaxs[mode])} (lmax={lrange[1]} requested)")
+            self._lmins[mode] = np.maximum(self._lmins[mode], lrange[0])
+            self._lmaxs[mode] = np.minimum(self._lmaxs[mode], lrange[1])
+        self._lmins['ET'] = self._lmins['TE']
+        self._lmaxs['ET'] = self._lmaxs['TE']
+        self.lmax = max(max(self._lmaxs[mode]) for mode in self.lrange)
     
 
     def _get_matrix_size(self):
@@ -305,7 +297,6 @@ class _HillipopLikelihood(InstallableLikelihood):
             lmax = self._lmaxs[mode][self._xspec2xfreq.index(xf)]
             wf = deepcopy( self.wf)
             wf.cut_binning( lmin, lmax)
-            wf.cut_binning( *self.lrange[mode])
             xl += list(wf.bin_spectra(acl[xf]))
         return xl
 

--- a/planck_2020_hillipop/hillipop.py
+++ b/planck_2020_hillipop/hillipop.py
@@ -96,6 +96,19 @@ class _HillipopLikelihood(InstallableLikelihood):
             self._cut_lrange()  # optional lrange cutting only for binned likelihood
         self._invkll = self._invkll.astype('float32')
 
+        # Precompute binning operators for _select_spectra
+        self._bin_p = {}
+        for mode in ["TT", "TE", "EE"]:
+            if not self._is_mode[mode]:
+                continue
+            for xf in range(self._nxfreq):
+                lmin = self._lmins[mode][self._xspec2xfreq.index(xf)]
+                lmax = self._lmaxs[mode][self._xspec2xfreq.index(xf)]
+                wf = deepcopy(self.wf)
+                wf.cut_binning(lmin, lmax)
+                p, _ = wf._bin_operators(Dl=False)
+                self._bin_p[(mode, xf)] = p
+
         # Data
         basename = os.path.join(self.data_folder, self.xspectra_basename)
         self._dldata = self._read_dl_xspectra(basename)
@@ -325,11 +338,9 @@ class _HillipopLikelihood(InstallableLikelihood):
         acl = np.asarray(cl)
         xl = []
         for xf in range(self._nxfreq):
-            lmin = self._lmins[mode][self._xspec2xfreq.index(xf)]
-            lmax = self._lmaxs[mode][self._xspec2xfreq.index(xf)]
-            wf = deepcopy( self.wf)
-            wf.cut_binning( lmin, lmax)
-            xl += list(wf.bin_spectra(acl[xf]))
+            p = self._bin_p[(mode, xf)]
+            minlmax = min(acl[xf].shape[0], p.shape[1])
+            xl += list(np.dot(acl[xf, :minlmax], p.T[:minlmax]))
         return xl
 
     def _xspectra_to_xfreq(self, cl, weight, normed=True):

--- a/planck_2020_hillipop/hillipop.py
+++ b/planck_2020_hillipop/hillipop.py
@@ -15,6 +15,7 @@ import numpy as np
 from cobaya.conventions import data_path, packages_path_input
 from cobaya.likelihoods.base_classes import InstallableLikelihood
 from cobaya.log import LoggedError
+from cobaya.mpi import is_main_process
 
 from . import foregrounds as fg
 from . import tools
@@ -64,6 +65,7 @@ class _HillipopLikelihood(InstallableLikelihood):
         self._nxfreq = self._nfreq * (self._nfreq + 1) // 2
         self._nxspec = self._nmap * (self._nmap - 1) // 2
         self._xspec2xfreq = self._xspec2xfreq()
+        self._xfreq_labels = self._xfreq_labels()
         self.log.debug(f"frequencies = {self.frequencies}")
 
         # Get likelihood name and add the associated mode
@@ -103,17 +105,6 @@ class _HillipopLikelihood(InstallableLikelihood):
         for m,w8 in dlsig.items(): w8[w8==0] = np.inf
         self._dlweight = {k:1/v**2 for k,v in dlsig.items()}
 
-        for xs, (m1, m2) in enumerate(combinations(self._mapnames, 2)):
-            logstr = f"{m1}x{m2}: "
-            for mode in ['TT','EE','TE']:
-                if self._is_mode[mode]:
-                    xflmin = self._lmins[mode][xs]
-                    xflmax = self._lmaxs[mode][xs]
-                    wf = deepcopy( self.wf)
-                    wf.cut_binning( xflmin, xflmax)
-                    logstr += f"{mode}[{wf.lmin:4d}-{wf.lmax:4d}]  "
-            self.log.info(logstr)
-
         # Foregrounds
         self.fgs = {tag:[] for tag,is_tag in self._is_mode.items() if is_tag}  # list of foregrounds per mode [TT,EE,TE,ET]
         if 'TE' in self.foregrounds: self.foregrounds['ET'] = self.foregrounds['TE']
@@ -132,6 +123,18 @@ class _HillipopLikelihood(InstallableLikelihood):
                                            self.foregrounds[tag]["cib"] and os.path.join(self.fgds_folder, self.foregrounds[tag]["cib"]))
                 fgs.append(getattr(fg,name)(**kwargs))
 
+        if is_main_process():
+            for xs, (m1, m2) in enumerate(combinations(self._mapnames, 2)):
+                logstr = f"{m1}x{m2}: "
+                for mode in ['TT','EE','TE']:
+                    if self._is_mode[mode]:
+                        xflmin = self._lmins[mode][xs]
+                        xflmax = self._lmaxs[mode][xs]
+                        wf = deepcopy( self.wf)
+                        wf.cut_binning( xflmin, xflmax)
+                        logstr += f"{mode}[{wf.lmin:4d}-{wf.lmax:4d}]  "
+                self.log.info(logstr)
+
         self.log.info("Initialized!")
 
     def _xspec2xfreq(self):
@@ -149,6 +152,14 @@ class _HillipopLikelihood(InstallableLikelihood):
                 spec2freq.append(list_fqs.index((f1, f2)))
 
         return spec2freq
+
+    def _xfreq_labels(self):
+        freqs = list(np.unique(self.frequencies))
+        labels = []
+        for f1 in range(self._nfreq):
+            for f2 in range(f1, self._nfreq):
+                labels.append(f"{freqs[f1]}x{freqs[f2]}")
+        return labels
 
     def _set_multipole_ranges(self, filename):
         """
@@ -227,10 +238,10 @@ class _HillipopLikelihood(InstallableLikelihood):
         self.log.debug(f"\tSet up lmin/lmax cuts for lrange:\n{self.lrange}")
         idx_offset = 0
         kept_idxs = []
-        for mode in ["TT", "EE", "TE"]:
-            if not self._is_mode[mode]:
+        for XY in ["TT", "EE", "TE"]:
+            if not self._is_mode[XY]:
                 continue
-            l_cuts = self.lrange.get(mode)
+            l_cuts = self.lrange.get(XY)
             if l_cuts is None:
                 lmin_cut = self.lmax
                 lmax_cut = self.lmin
@@ -238,14 +249,14 @@ class _HillipopLikelihood(InstallableLikelihood):
                 lmin_cut, lmax_cut = l_cuts
 
             # validate lrange
-            if lmin_cut < min(self._lmins[mode]):
-                raise LoggedError(self.log, f"{mode} lmin should be >= {min(self._lmins[mode])} (lmin={lmin_cut} requested)")
-            if lmax_cut > max(self._lmaxs[mode]):
-                raise LoggedError(self.log, f"{mode} lmax should be <= {max(self._lmaxs[mode])} (lmax={lmax_cut} requested)")
+            if lmin_cut < min(self._lmins[XY]):
+                raise LoggedError(self.log, f"{XY} lmin should be >= {min(self._lmins[XY])} (lmin={lmin_cut} requested)")
+            if lmax_cut > max(self._lmaxs[XY]):
+                raise LoggedError(self.log, f"{XY} lmax should be <= {max(self._lmaxs[XY])} (lmax={lmax_cut} requested)")
 
             for xf in range(self._nxfreq):
-                xflmin = self._lmins[mode][self._xspec2xfreq.index(xf)]
-                xflmax = self._lmaxs[mode][self._xspec2xfreq.index(xf)]
+                xflmin = self._lmins[XY][self._xspec2xfreq.index(xf)]
+                xflmax = self._lmaxs[XY][self._xspec2xfreq.index(xf)]
 
                 wf = deepcopy(self.wf)
                 wf.cut_binning(xflmin, xflmax)
@@ -254,13 +265,27 @@ class _HillipopLikelihood(InstallableLikelihood):
                 kept_idxs.extend(idx_offset + np.flatnonzero(mask))
                 idx_offset += wf.nbins
 
-            # integrate lrange into _lmins/_lmaxs
-            self._lmins[mode] = np.maximum(self._lmins[mode], lmin_cut)
-            self._lmaxs[mode] = np.minimum(self._lmaxs[mode], lmax_cut)
+                if mask.sum() < len(mask) and is_main_process():
+                    if mask.any():
+                        self.log.info(
+                            f"Cutting {XY} {self._xfreq_labels[xf]} to [{lmin_cut}, {lmax_cut}]. "
+                            f"Keeping {mask.sum()}/{len(mask)} bins "
+                            f"(effective range [{wf.lmins[mask].min()}, {wf.lmaxs[mask].max()}])."
+                        )
+                    else:
+                        self.log.info(f"Removing {XY} {self._xfreq_labels[xf]} entirely ({len(mask)} bins cut).")
 
-        self._lmins['ET'] = self._lmins['TE']
-        self._lmaxs['ET'] = self._lmaxs['TE']
-        self.lmax = max(max(self._lmaxs[mode]) for mode in self.lrange)
+            # integrate lrange into _lmins/_lmaxs
+            X, Y = XY
+            for YX in {XY, Y+X}:
+                if l_cuts is not None:
+                    self._lmins[YX] = np.maximum(self._lmins[XY], lmin_cut)
+                    self._lmaxs[YX] = np.minimum(self._lmaxs[XY], lmax_cut)
+                else:
+                    self._is_mode[YX] = False
+                    self._lmins.pop(YX, None)
+                    self._lmaxs.pop(YX, None)
+        self.lmax = max(max(self._lmaxs[XY]) for XY in self.lrange)
 
         # early exit if nothing was cut
         if len(kept_idxs) == self._invkll.shape[0]:

--- a/planck_2020_hillipop/hillipop.py
+++ b/planck_2020_hillipop/hillipop.py
@@ -229,6 +229,7 @@ class _HillipopLikelihood(InstallableLikelihood):
         data = fits.getdata(filename)
         nel = int(np.sqrt(data.size))
         data = data.reshape((nel, nel)) / 1e24  # muK^-4
+        data = 0.5 * (data + data.T)  # ensure exact symmetry
 
         nell = self._get_matrix_size()
         if nel != nell:

--- a/planck_2020_hillipop/hillipop.py
+++ b/planck_2020_hillipop/hillipop.py
@@ -223,14 +223,19 @@ class _HillipopLikelihood(InstallableLikelihood):
         Apply multipole cuts from `lrange` on the covariance matrix and lmins/lmaxs.
         """
 
-        # resize with lmax
+        # build index list for covariance cutting
         self.log.debug(f"\tSet up lmin/lmax cuts for lrange:\n{self.lrange}")
-        shift = 0
-        idxs = []
+        idx_offset = 0
+        kept_idxs = []
         for mode in ["TT", "EE", "TE"]:
             if not self._is_mode[mode]:
                 continue
-            lmin_cut, lmax_cut = self.lrange[mode]
+            l_cuts = self.lrange.get(mode)
+            if l_cuts is None:
+                lmin_cut = self.lmax
+                lmax_cut = self.lmin
+            else:
+                lmin_cut, lmax_cut = l_cuts
 
             # validate lrange
             if lmin_cut < min(self._lmins[mode]):
@@ -238,7 +243,6 @@ class _HillipopLikelihood(InstallableLikelihood):
             if lmax_cut > max(self._lmaxs[mode]):
                 raise LoggedError(self.log, f"{mode} lmax should be <= {max(self._lmaxs[mode])} (lmax={lmax_cut} requested)")
 
-            # build index list for covariance cutting
             for xf in range(self._nxfreq):
                 xflmin = self._lmins[mode][self._xspec2xfreq.index(xf)]
                 xflmax = self._lmaxs[mode][self._xspec2xfreq.index(xf)]
@@ -246,9 +250,9 @@ class _HillipopLikelihood(InstallableLikelihood):
                 wf = deepcopy(self.wf)
                 wf.cut_binning(xflmin, xflmax)
 
-                for i in range(wf.nbins):
-                    if wf.lmins[i] >= lmin_cut and wf.lmaxs[i] <= lmax_cut: idxs.append(shift+i)
-                shift += wf.nbins
+                mask = (wf.lmins >= lmin_cut) & (wf.lmaxs <= lmax_cut)
+                kept_idxs.extend(idx_offset + np.flatnonzero(mask))
+                idx_offset += wf.nbins
 
             # integrate lrange into _lmins/_lmaxs
             self._lmins[mode] = np.maximum(self._lmins[mode], lmin_cut)
@@ -258,12 +262,16 @@ class _HillipopLikelihood(InstallableLikelihood):
         self._lmaxs['ET'] = self._lmaxs['TE']
         self.lmax = max(max(self._lmaxs[mode]) for mode in self.lrange)
 
-        # invert matrix
+        # early exit if nothing was cut
+        if len(kept_idxs) == self._invkll.shape[0]:
+            return
+
+        # invert, cut, re-invert covariance matrix
         self.log.debug("\tInvert invkll matrix")
         kll = np.linalg.inv(self._invkll)
-        kll = kll[idxs,:][:,idxs]
+        kll = kll[kept_idxs,:][:,kept_idxs]
         self.log.debug("\tInvert kll matrix")
-        self._invkll = np.linalg.inv( kll)
+        self._invkll = np.linalg.inv(kll)
 
     def _get_matrix_size(self):
         """

--- a/planck_2020_hillipop/hillipop.py
+++ b/planck_2020_hillipop/hillipop.py
@@ -34,6 +34,7 @@ data_url = "https://portal.nersc.gov/cfs/cmb/planck2020/likelihoods"
 
 
 class _HillipopLikelihood(InstallableLikelihood):
+    bibtex_file = 'hillipop.bibtex'
     multipoles_range_file: Optional[str]
     xspectra_basename: Optional[str]
     covariance_matrix_file: Optional[str]


### PR DESCRIPTION
Salut Matthieu,

here some suggestions. Looking at the entire diff might be a bit confusing, the individual commits might be more helpful.

## Summary

* **Refactor `_cut_covmatrix` --> `_cut_lrange`**: Rewritten with boolean mask instead of manual index loop, early exit when nothing is cut, and support for partial `lrange` (modes absent from `lrange` are removed entirely rather than requiring all modes to be specified).
* **Reorder initialization**: Move binning setup (`self.wf`) and covariance reading + `lrange` cutting before data reading, so `self.lmax` is finalised before data is loaded.
* **Enforce covariance symmetry**: `data = 0.5 * (data + data.T)` on read, since the stored matrix has floating-point asymmetry.
* **Precompute binning operators**: Cache per-(mode, xfreq) `p` matrices at init, replacing the per-evaluation `deepcopy` + `cut_binning` + `_bin_operators` chain in `_select_spectra` (~175 ms --> ~25 ms, i.e. 7x speedup).
* **Add informative logging**: Per-cross-frequency log messages when `lrange` cuts bins, and per-cross-spectrum summary of effective multipole ranges at end of init (MPI-rank guarded).
* **Cosmetic clean-ups**: Fix bibtex, correct type hints (`list` --> `dict`), remove commented-out code and stray `print`, consistent docstring punctuation.
